### PR TITLE
Start session after NICK+PASS, fix segfault

### DIFF
--- a/rcirc.c
+++ b/rcirc.c
@@ -1461,6 +1461,8 @@ skip_parsing:
 
 			IFFREE(s->irc.nick);
 			s->irc.nick = strdup(c);
+			if (s->rc.token && !s->rc_poll)
+				sess__rc_start(s, ctx);
 		}
 
 	} else if (!strcmp(command, "USER")) {
@@ -1471,7 +1473,8 @@ skip_parsing:
 		IFFREE(s->rc.token);
 		if (*c == ':') c++;
 		s->rc.token = strdup(c);
-		sess__rc_start(s, ctx);
+		if (s->irc.nick)
+			sess__rc_start(s, ctx);
 	} else if (c && !strcmp(command, "PRIVMSG")) {
 		char *msg = strchr(c, ' ');
 		char t;
@@ -1500,9 +1503,10 @@ skip_parsing:
 		sess__rc_join_room(s, 'd', c);
 	} else if (!strcmp(command, "QUIT")) {
 		shutdown(s->poll->fd, SHUT_RDWR);
-		shutdown(s->rc_poll->fd, SHUT_RDWR);
+		if (s->rc_poll)
+			shutdown(s->rc_poll->fd, SHUT_RDWR);
 	} else {
-		logg(ERR, "Unrecognized command %s\n", command);
+		logg(ERR, "Unrecognized command %s %s\n", command, c ? c : "");
 	}
 
  error_parsing:


### PR DESCRIPTION
Three things:
* protect shutdown by s->rc_poll test, it might be NULL after a QUIT,
  but before a real disconnect from the IRC client
* dump arguments to unknown commands as well
* start the session only after both PASS _and_ NICK are received by
  IRC client: only after both of them an IRC session is supposed to be
  active, and some clients (e.g. konversation) don't expect things
  like channel lists or the real RC nick before they sent NICK, so
  just wait with establishing the RC session after both are received.