### PR TITLE
Initialize socklen_t with length of struct sockaddr_in

### DIFF
--- a/rcirc.c
+++ b/rcirc.c
@@ -1633,7 +1633,7 @@ int main(int argc, char **argv)
 		if (ret > 0 && pollfds[0].revents == POLLIN) {
 			/* new connection on the IRC port */
 			struct sockaddr_in cl_addr;
-			socklen_t cl_len;
+			socklen_t cl_len = sizeof(cl_addr);
 
 			int newfd =
 			    accept(pollfds[0].fd,


### PR DESCRIPTION
As `man accept` specifies, the value pointer by the `address_len` parameter must be initialized on input with the length of the supplied `sockaddr` structure. Failing to do this will cause `accept` to read uninitialized values from the stack, occasionally returning EINVAL.